### PR TITLE
[MRG] Bump to version 0.3.dev0

### DIFF
--- a/sklr/__init__.py
+++ b/sklr/__init__.py
@@ -32,7 +32,7 @@ problems that are accessible to everybody and reusable in all contexts.
 #
 # Dev branch marker is: "X.Y.dev" or "X.Y.devN" where N is an integer.
 # "X.Y.dev0" is the canonical version of "X.Y.dev".
-__version__ = "0.2.dev0"
+__version__ = "0.3.dev0"
 
 
 # =============================================================================


### PR DESCRIPTION
#### Reference Issues/PRs

Close #6.

#### What does this implement/fix?

Move to the development of `0.3` on `master`.
