### PR TITLE
[MRG] Add support for Python 3.8 version

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Checkout master branch
         uses: actions/checkout@v1
 
-      # Setup the Python 3.7 version
-      - name: Setup Python 3.7
+      # Setup the Python 3.8 version
+      - name: Setup Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       # Install the dependencies
       - name: Install dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,12 +18,12 @@ jobs:
       # the Python versions supported by scikit-lr
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python: ["3.6", "3.7"]
+        python: ["3.6", "3.7", "3.8"]
     # Specify the enviroment variables
     env:
-        NUMPY_VERSION: 1.15.2
-        SCIPY_VERSION: 1.1.0
-        CYTHON_VERSION: 0.29.0
+        NUMPY_VERSION: 1.17.3
+        SCIPY_VERSION: 1.3.2
+        CYTHON_VERSION: 0.29.14
     # Execute the following steps in the workflow
     steps:
       # Checkout the branch that issue the workflow

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v1
 
-      # Setup the Python 3.7 version
-      - name: Setup Python 3.7
+      # Setup the Python 3.8 version
+      - name: Setup Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       # Install the dependencies
       - name: Install dependencies


### PR DESCRIPTION
#### Reference Issues/PRs

Close #16. 

#### What does this implement/fix?

Adds support for `Python 3.8` version in the workflows of `GitHub actions`.

#### Any other comments?

The versions of `NumPy`, `SciPy` and `Cython` has had to be upgraded to `1.17.3`, `1.3.2` and `0.29.14` (respectively) in the `Continuous integration tests` workflow (due to compatibility purposes between versions).
