### PR TITLE
[MRG] Configure the workflows to run on master and release branches

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,11 +8,11 @@ on:
   push:
     branches:
       - master
-      - [0-9]+.[0-9]+.X
+      - "[0-9]+.[0-9]+.X"
   pull_request:
     branches:
       - master
-      - [0-9]+.[0-9]+.X
+      - "[0-9]+.[0-9]+.X"
 
 jobs:
   # Linux and MacOS environments to test that

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,18 @@
 name: Continuous integration tests
 
-# This workflow is triggered on each push and
-# pull request to ensure that the tests passed
-# before and after merging the master branch
-on: [push, pull_request]
+# This workflow will be triggered on each push or pull request
+# but only for the master and release branches, since feature
+# and bug-fix branches will be merged via pull request. Thus,
+# it ensures that changes are integrated without any issue
+on:
+  push:
+    branches:
+      - master
+      - [0-9]+.[0-9]+.X
+  pull_request:
+    branches:
+      - master
+      - [0-9]+.[0-9]+.X
 
 jobs:
   # Linux and MacOS environments to test that

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,11 +8,11 @@ on:
   push:
     branches:
       - master
-      - [0-9]+.[0-9]+.X
+      - "[0-9]+.[0-9]+.X"
   pull_request:
     branches:
       - master
-      - [0-9]+.[0-9]+.X
+      - "[0-9]+.[0-9]+.X"
 
 jobs:
   # Linux environment to test that PRs do not add

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,8 +1,18 @@
 name: Linting tests
 
-# This workflow is triggered on
-# each push and pull request
-on: [push, pull_request]
+# This workflow will be triggered on each push or pull request
+# but only for the master and release branches, since feature
+# and bug-fix branches will be merged via pull request. Thus,
+# it ensures that changes are integrated without any issue
+on:
+  push:
+    branches:
+      - master
+      - [0-9]+.[0-9]+.X
+  pull_request:
+    branches:
+      - master
+      - [0-9]+.[0-9]+.X
 
 jobs:
   # Linux environment to test that PRs do not add


### PR DESCRIPTION
#### What does this implement/fix?

Ensures that the `Continuous integration tests` and `Linting tests` are only run on pushes or pull requests for the `master` and `release` branches, since `feature` and `bug-fix` branches will be merged via pull request on them.