### PR TITLE
[MRG] Improve aggregation algorithm for bucket orders

### DIFF
--- a/sklr/consensus.pyx
+++ b/sklr/consensus.pyx
@@ -1108,16 +1108,11 @@ cdef class PairOrderMatrixBuilder:
                     precedences_matrix[f_class, s_class, 1] += weight
                 # Otherwise, apply the standard procedure
                 else:
-                    # Since either "f_class" or "s_class" is missed,
-                    # then either "f_class" could precede "s_class"
-                    # or viceversa. Moreover, it is also considered
-                    # that they can be tied
+                    # By-pass the information of this precedence relation if
+                    # either "f_class" or "s_class" is missed in this ranking
                     if (y[f_class] == RANK_TYPE.RANDOM or
                             y[s_class] == RANK_TYPE.RANDOM):
-                        precedences_matrix[f_class, s_class, 0] += weight
-                        precedences_matrix[s_class, f_class, 0] += weight
-                        precedences_matrix[f_class, s_class, 1] += weight
-                        precedences_matrix[s_class, f_class, 1] += weight
+                        pass
                     # "f_class" precedes "s_class", put the
                     # corresponding weight in the entry
                     # where counting the precedences


### PR DESCRIPTION
#### Reference Issues/PRs

Close #34.

#### What does this implement/fix?

Improves the aggregation algorithm for bucket orders when dealing with incomplete (randomly missed) bucket orders.

#### Any other comments

Previously, if a class was missed in a ranking, we considered that it can precede, be tied or ranked behind any other class, when filling the information of the precedence matrix. Now, we by-pass the information to avoid that this kind of "_random noise_" is introduced, so generating more reliable and robust consensus rankings.