### PR TITLE
[MRG] Include the C++ source files with the Cython extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.so
 *.c
 *.cpp
+!/**/src/**/*.cpp
 
 # Distribution and packaging
 build/


### PR DESCRIPTION
#### What does this implement/fix?

Implements in the `_build_utils` module that the `C++` source files that are available in a directory are included with the `Cython` extensions.

#### Any other comments?

Updates `.gitignore` to exclude the `C++` source files under the `src` directory.