### PR TITLE
[DOC] Add glossary terms to the exceptions module

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,7 +79,8 @@ autosummary_generate = True
 # Map the name to the location of other projects
 intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "scikit-learn": ("https://scikit-learn.org/stable", None),
+    "python": ("https://docs.python.org/3/", None),
+    "scikit-learn": ("https://scikit-learn.org/stable", None)
 }
 
 # Link the source code of an object to the repository

--- a/sklr/exceptions.py
+++ b/sklr/exceptions.py
@@ -15,10 +15,10 @@ __all__ = ["NotFittedError"]
 # =============================================================================
 
 class NotFittedError(ValueError, AttributeError):
-    """Exception class to raise if estimator is used before fitting.
+    """Exception to raise if :term:`estimator` is used before :term:`fitting`.
 
-    This class inherits from both ``ValueError`` and ``AttributeError``
-    to help with exception handling and backward compatibility.
+    This class inherits from :class:`ValueError` and :class:`AttributeError`
+    to help with exception handling and :term:`backwards compatibility`.
 
     Examples
     --------


### PR DESCRIPTION
#### Reference issues

Partially addresses #11.

#### What does this implement?

This PR adds terms of the glossary to the `sklr.exceptions` module.