### PR TITLE
[MRG] Add glossary terms to the datasets module

### DIFF
--- a/docs/source/user_guide/datasets.rst
+++ b/docs/source/user_guide/datasets.rst
@@ -17,9 +17,9 @@ The main dataset interface can be used to load
 :ref:`real-world datasets <real_world_datasets>`.
 
 These functions return a tuple ``(X, Y)`` consisting of a
-``(n_samples, n_features)`` :func:`numpy.array` ``X`` and
-an array of shape ``(n_samples, n_classes)`` containing
-the target rankings ``Y``.
+``(n_samples, n_features)`` :class:`numpy.ndarray` ``X`` and
+an array of shape ``(n_samples, n_classes)`` containing the
+:term:`target` :term:`rankings` ``Y``.
 
 .. _toy_datasets:
 
@@ -54,9 +54,10 @@ We provide standard datasets that can be loaded using the following functions:
     load_wisconsin
     load_yeast
 
-These datasets were obtained by transforming multi-class and regression
-problems of the `UCI Machine Learning Repository`_ to the Label Ranking
-problem and the Partial Label Ranking problem.
+These datasets were obtained by transforming :term:`multiclass`
+and :term:`continuous` (regression) problems of the `UCI Machine
+Learning Repository`_ to the label ranking problem and the partial
+label ranking problem.
 
 .. topic:: References:
 
@@ -454,10 +455,10 @@ These datasets originate from the bioinformatics fields considering two types
 of genetic data, namely phylogenetic profiles and microarray expression data
 for the Yeast genome. The Yeast genome consists of genes, and each gene is
 represented by an associated phylogenetic profile. Using these profiles as
-input features, the expression profile of a gene is ordered into ranks. The
-use of five microarray experiments (spo, heat, dtt, cold, diau), gives rise
-to five prediction problems allusing the same input features but different
-target rankings.
+input :term:`features`, the expression profile of a gene is ordered into
+ranks. The use of five microarray experiments (spo, heat, dtt, cold, diau),
+gives rise to five prediction problems allusing the same input features but
+different target rankings.
 
 .. topic:: References:
 

--- a/sklr/datasets/_base.py
+++ b/sklr/datasets/_base.py
@@ -26,7 +26,7 @@ MODULE_PATH = dirname(__file__)
 # =============================================================================
 
 def load_data(module_path, problem, data_file_name):
-    """Load data from ``module_path/data/problem/data_file_name``.
+    """Load data from module_path/data/problem/data_file_name.
 
     Parameters
     ----------
@@ -37,19 +37,18 @@ def load_data(module_path, problem, data_file_name):
         The problem for which the data will be loaded.
 
     data_file_name : str
-        The name of ``.csv`` file to be loaded from
-        ``module_path/data/problem/data_file_name``.
-        For example, '``wine.csv``'.
+        The name of .csv file to be loaded from
+        module_path/data/problem/data_file_name.
 
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
+        A 2d array with each row representing one sample and each
         column representing the features of a given sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding target rankings for all samples in data.
+        For example, ranks[0] is the target ranking of data[0].
     """
     with open(join(module_path, "data", problem, data_file_name)) \
             as csv_file:
@@ -93,12 +92,14 @@ def load_authorship(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -142,12 +143,14 @@ def load_blocks(*, problem="partial_label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -186,12 +189,14 @@ def load_bodyfat(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -230,12 +235,14 @@ def load_breast(*, problem="partial_label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -274,12 +281,14 @@ def load_calhousing(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -318,12 +327,14 @@ def load_cold(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -362,12 +373,14 @@ def load_cpu(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -406,12 +419,14 @@ def load_diau(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -450,12 +465,14 @@ def load_dtt(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -494,12 +511,14 @@ def load_ecoli(*, problem="partial_label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -538,12 +557,14 @@ def load_elevators(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -582,12 +603,14 @@ def load_fried(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -627,12 +650,14 @@ def load_glass(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -676,12 +701,14 @@ def load_heat(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -720,12 +747,14 @@ def load_housing(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -765,12 +794,14 @@ def load_iris(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -814,12 +845,14 @@ def load_letter(*, problem="partial_label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -861,12 +894,14 @@ def load_libras(*, problem="partial_label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -906,12 +941,14 @@ def load_pendigits(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -955,12 +992,14 @@ def load_satimage(*, problem="partial_label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -1000,12 +1039,14 @@ def load_segment(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -1049,12 +1090,14 @@ def load_spo(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -1093,12 +1136,14 @@ def load_stock(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -1138,12 +1183,14 @@ def load_vehicle(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -1188,12 +1235,14 @@ def load_vowel(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -1238,12 +1287,14 @@ def load_wine(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -1287,12 +1338,14 @@ def load_wisconsin(*, problem="label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------
@@ -1331,12 +1384,14 @@ def load_yeast(*, problem="partial_label_ranking"):
     Returns
     -------
     data : ndarray of shape (n_samples, n_features), dtype=np.float64
-        A 2-D array with each row representing one sample and each
-        column representing the features of a given sample.
+        A :term:`2d array` with each row representing one :term:`sample`
+        and each column representing the :term:`features` of a given
+        sample.
 
     ranks : ndarray of shape (n_samples, n_classes), dtype=np.int64
-        A 2-D array holding target rankings for all the samples in `data`.
-        For example, ``ranks[0]`` is the target ranking for ``data[0]``.
+        A 2d array holding :term:`target` :term:`rankings` for all samples
+        in `data`. For example, ``ranks[0]`` is the target ranking of
+        ``data[0]``.
 
     Examples
     --------

--- a/sklr/datasets/tests/test_base.py
+++ b/sklr/datasets/tests/test_base.py
@@ -121,8 +121,7 @@ def test_load_fried(problem):
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_glass(problem):
     """Test the load_glass function."""
-    check_data(load_glass, problem,
-               (214, 9, 6, 30, 105, 6, 4.08879))
+    check_data(load_glass, problem, (214, 9, 6))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)

--- a/sklr/datasets/tests/test_base.py
+++ b/sklr/datasets/tests/test_base.py
@@ -6,7 +6,6 @@
 # =============================================================================
 
 # Third party
-import numpy as np
 import pytest
 
 # Local application
@@ -34,224 +33,183 @@ BOTH_PROBLEMS = [*LABEL_RANKING, *PARTIAL_LABEL_RANKING]
 # Functions
 # =============================================================================
 
-def _num_buckets(Y):
-    """Find the mean number of buckets."""
-    return np.mean([np.unique(y).shape[0] for y in Y])
-
-
-def _num_unique_rankings(Y):
-    """Find the number of unique rankings."""
-    return np.unique(Y, axis=0).shape[0]
-
-
 def check_data(load_data, problem, shape):
-    """Check the shape of the data provided by the method."""
+    """Check the shape of the data to load."""
     (data, ranks) = load_data(problem=problem)
 
     n_samples = shape[0]
     n_features = shape[1]
     n_classes = shape[2]
-    n_rankings = shape[3 if problem == "label_ranking" else 4]
-    n_buckets = shape[5 if problem == "label_ranking" else 6]
 
     assert data.shape[0] == ranks.shape[0] == n_samples
     assert data.shape[1] == n_features
     assert ranks.shape[1] == n_classes
-    assert _num_unique_rankings(ranks) == n_rankings
-    np.testing.assert_almost_equal(_num_buckets(ranks), n_buckets, decimal=5)
 
 
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_authorship(problem):
-    """Test the load_authorship method."""
-    check_data(load_authorship, problem,
-               (841, 70, 4, 17, 47, 4, 3.06302))
+    """Test the load_authorship function."""
+    check_data(load_authorship, problem, (841, 70, 4))
 
 
 @pytest.mark.parametrize("problem", PARTIAL_LABEL_RANKING)
 def test_load_blocks(problem):
-    """Test the load_blocks method."""
-    check_data(load_blocks, problem,
-               (5472, 10, 5, None, 116, None, 2.33662))
+    """Test the load_blocks function."""
+    check_data(load_blocks, problem, (5472, 10, 5))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_bodyfat(problem):
-    """Test the load_bodyfat method."""
-    check_data(load_bodyfat, problem,
-               (252, 7, 7, 236, None, 7, None))
+    """Test the load_bodyfat function."""
+    check_data(load_bodyfat, problem, (252, 7, 7))
 
 
 @pytest.mark.parametrize("problem", PARTIAL_LABEL_RANKING)
 def test_load_breast(problem):
-    """Test the load_breast method."""
-    check_data(load_breast, problem,
-               (106, 9, 6, None, 62, None, 3.92453))
+    """Test the load_breast function."""
+    check_data(load_breast, problem, (106, 9, 6))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_calhousing(problem):
-    """Test the load_calhousing method."""
-    check_data(load_calhousing, problem,
-               (20640, 4, 4, 24, None, 4, None))
+    """Test the load_calhousing function."""
+    check_data(load_calhousing, problem, (20640, 4, 4))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_cold(problem):
-    """Test the load_cold method."""
-    check_data(load_cold, problem,
-               (2465, 24, 4, 24, None, 4, None))
+    """Test the load_cold function."""
+    check_data(load_cold, problem, (2465, 24, 4))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_cpu(problem):
-    """Test the load_cpu method."""
-    check_data(load_cpu, problem,
-               (8192, 6, 5, 119, None, 5, None))
+    """Test the load_cpu function."""
+    check_data(load_cpu, problem, (8192, 6, 5))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_diau(problem):
-    """Test the load_diau method."""
-    check_data(load_diau, problem,
-               (2465, 24, 7, 967, None, 7, None))
+    """Test the load_diau function."""
+    check_data(load_diau, problem, (2465, 24, 7))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_dtt(problem):
-    """Test the load_dtt method."""
-    check_data(load_dtt, problem,
-               (2465, 24, 4, 24, None, 4, None))
+    """Test the load_dtt function."""
+    check_data(load_dtt, problem, (2465, 24, 4))
 
 
 @pytest.mark.parametrize("problem", PARTIAL_LABEL_RANKING)
 def test_load_ecoli(problem):
-    """Test the load_ecoli method."""
-    check_data(load_ecoli, problem,
-               (336, 7, 8, None, 179, None, 4.13988))
+    """Test the load_ecoli function."""
+    check_data(load_ecoli, problem, (336, 7, 8))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_elevators(problem):
-    """Test the load_elevators method."""
-    check_data(load_elevators, problem,
-               (16599, 9, 9, 131, None, 9, None))
+    """Test the load_elevators function."""
+    check_data(load_elevators, problem, (16599, 9, 9))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_fried(problem):
-    """Test the load_fried method."""
-    check_data(load_fried, problem,
-               (40768, 9, 5, 120, None, 5, None))
+    """Test the load_fried function."""
+    check_data(load_fried, problem, (40768, 9, 5))
 
 
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_glass(problem):
-    """Test the load_glass method."""
+    """Test the load_glass function."""
     check_data(load_glass, problem,
                (214, 9, 6, 30, 105, 6, 4.08879))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_heat(problem):
-    """Test the load_heat method."""
-    check_data(load_heat, problem,
-               (2465, 24, 6, 622, None, 6, None))
+    """Test the load_heat function."""
+    check_data(load_heat, problem, (2465, 24, 6))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_housing(problem):
-    """Test the load_housing method."""
-    check_data(load_housing, problem,
-               (506, 6, 6, 112, None, 6, None))
+    """Test the load_housing function."""
+    check_data(load_housing, problem, (506, 6, 6))
 
 
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_iris(problem):
-    """Test the load_iris method."""
-    check_data(load_iris, problem,
-               (150, 4, 3, 5, 7, 3, 2.38000))
+    """Test the load_iris function."""
+    check_data(load_iris, problem, (150, 4, 3))
 
 
 @pytest.mark.parametrize("problem", PARTIAL_LABEL_RANKING)
 def test_load_letter(problem):
-    """Test the load_letter method."""
-    check_data(load_letter, problem,
-               (20000, 16, 26, None, 15014, None, 7.03260))
+    """Test the load_letter function."""
+    check_data(load_letter, problem, (20000, 16, 26))
 
 
 @pytest.mark.parametrize("problem", PARTIAL_LABEL_RANKING)
 def test_load_libras(problem):
-    """Test the load_libras method."""
-    check_data(load_libras, problem,
-               (360, 90, 15, None, 356, None, 6.88889))
+    """Test the load_libras function."""
+    check_data(load_libras, problem, (360, 90, 15))
 
 
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_pendigits(problem):
-    """Test the load_pendigits method."""
-    check_data(load_pendigits, problem,
-               (10992, 16, 10, 2081, 3327, 10, 3.39747))
+    """Test the load_pendigits function."""
+    check_data(load_pendigits, problem, (10992, 16, 10))
 
 
 @pytest.mark.parametrize("problem", PARTIAL_LABEL_RANKING)
 def test_load_satimage(problem):
-    """Test the load_satimage method."""
-    check_data(load_satimage, problem,
-               (6435, 36, 6, None, 504, None, 3.35649))
+    """Test the load_satimage function."""
+    check_data(load_satimage, problem, (6435, 36, 6))
 
 
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_segment(problem):
-    """Test the load_segment method."""
-    check_data(load_segment, problem,
-               (2310, 18, 7, 135, 271, 7, 3.03074))
+    """Test the load_segment function."""
+    check_data(load_segment, problem, (2310, 18, 7))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_spo(problem):
-    """Test the load_spo method."""
-    check_data(load_spo, problem,
-               (2465, 24, 11, 2361, None, 11, None))
+    """Test the load_spo function."""
+    check_data(load_spo, problem, (2465, 24, 11))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_stock(problem):
-    """Test the load_stock method."""
-    check_data(load_stock, problem,
-               (950, 5, 5, 51, None, 5, None))
+    """Test the load_stock function."""
+    check_data(load_stock, problem, (950, 5, 5))
 
 
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_vehicle(problem):
-    """Test the load_vehicle method."""
-    check_data(load_vehicle, problem,
-               (846, 18, 4, 18, 47, 4, 3.11702))
+    """Test the load_vehicle function."""
+    check_data(load_vehicle, problem, (846, 18, 4))
 
 
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_vowel(problem):
-    """Test the load_vowel method."""
-    check_data(load_vowel, problem,
-               (528, 10, 11, 294, 504, 11, 5.73863))
+    """Test the load_vowel function."""
+    check_data(load_vowel, problem, (528, 10, 11))
 
 
 @pytest.mark.parametrize("problem", BOTH_PROBLEMS)
 def test_load_wine(problem):
-    """Test the load_wine method."""
-    check_data(load_wine, problem,
-               (178, 13, 3, 5, 11, 3, 2.67978))
+    """Test the load_wine function."""
+    check_data(load_wine, problem, (178, 13, 3))
 
 
 @pytest.mark.parametrize("problem", LABEL_RANKING)
 def test_load_wisconsin(problem):
-    """Test the load_wisconsin method."""
-    check_data(load_wisconsin, problem,
-               (194, 16, 16, 194, None, 16, None))
+    """Test the load_wisconsin function."""
+    check_data(load_wisconsin, problem, (194, 16, 16))
 
 
 @pytest.mark.parametrize("problem", PARTIAL_LABEL_RANKING)
 def test_load_yeast(problem):
-    """Test the load_yeast method."""
-    check_data(load_yeast, problem,
-               (1484, 8, 10, None, 1006, None, 5.92925))
+    """Test the load_yeast function."""
+    check_data(load_yeast, problem, (1484, 8, 10))

--- a/sklr/utils/ranking.py
+++ b/sklr/utils/ranking.py
@@ -18,6 +18,16 @@ from ._ranking import is_label_ranking, is_partial_label_ranking
 # Methods
 # =============================================================================
 
+def num_buckets(Y):
+    """Find the mean number of buckets."""
+    return np.mean([np.unique(y).shape[0] for y in Y])
+
+
+def unique_rankings(Y):
+    """Find the number of unique rankings."""
+    return np.unique(Y, axis=0)
+
+
 def check_label_ranking_targets(Y):
     """Ensure that target ``Y`` is of a Label Ranking type.
 


### PR DESCRIPTION
#### Reference issues

Partially addresses #11.

#### What does this implement?

This PR adds terms of the glossary to the `sklr.datasets` module.