### PR TITLE
[MRG] Update numpydoc and scikit-learn versions in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ COPY requirements.txt /req/
 RUN pip install --upgrade pip; \
     pip install -r /req/requirements.txt
 
-# Install from the source code of the repository
+# Install from source
 ARG SOURCE_COMMIT
 RUN echo "Installing commit $SOURCE_COMMIT."
 RUN pip install git+git://github.com/alfaro96/scikit-lr.git@$SOURCE_COMMIT

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ COPY requirements.txt /req/
 RUN pip install --upgrade pip; \
     pip install -r /req/requirements.txt
 
-# Install the package from the source code of the repository
+# Install from the source code of the repository
 ARG SOURCE_COMMIT
 RUN echo "Installing commit $SOURCE_COMMIT."
 RUN pip install git+git://github.com/alfaro96/scikit-lr.git@$SOURCE_COMMIT

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,11 +5,14 @@
 
 # Using scikit-lr via Docker
 
-This directory contains a `Dockerfile` to make it easy to get up and running with scikit-lr via [Docker](https://docker.com).
+This directory contains a `Dockerfile` to make it easy to get
+up and running with scikit-lr via [Docker](https://docker.com).
 
 ## Installing Docker
 
-General installation instructions are [on the Docker site](https://docs.docker.com/get-docker/), but we give some quick links here:
+General installation instructions are
+[on the Docker site](https://docs.docker.com/get-docker/),
+but we give some quick links here:
 
 * [Installing Docker Engine](https://docs.docker.com/engine/install/)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,7 +28,7 @@ make build
 
 ## Pulling the image
 
-To pull the image from [Docker Hub](https://hub.docker.com):
+To pull the image from [Docker Hub](https://hub.docker.com/r/alfaro96/scikit-lr):
 
 ```
 make pull

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,13 +1,13 @@
 numpy==1.17.3
 scipy==1.3.2
 cython==0.29.14
+scikit-learn==0.22.0
 pytest==4.6.4
 coverage==4.5.4
 pytest-cov==2.8.0
 flake8==3.7.9
 sphinx==3.0.3
 sphinx-rtd-theme==0.4.3
-numpydoc==0.9.2
+numpydoc==1.0.0
 pandas==1.0.3
-scikit-learn==0.23.1
 jupyterlab==2.1.2


### PR DESCRIPTION
<!--- Standard template for submitting PRs -->

#### What does this implement?

This PR updates the `numpydoc` version to `1.0.0` and the `scikit-learn` one to `0.22.0`.

#### Any other comments?

Apply minor changes to the `README.md` fie.