### PR TITLE
[MRG] Fix installation of scikit-learn nightly build

### DIFF
--- a/.github/tools/cron/install.sh
+++ b/.github/tools/cron/install.sh
@@ -11,7 +11,7 @@ pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy cython
 
 echo "Installing scikit-learn."
 dev_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
-pip install --pre --upgrade --timeout=60 -i $dev_url scikit-learn
+pip install --pre --upgrade --timeout=60 --extra-index $dev_url scikit-learn
 
 echo "Installing pytest."
 pip install pytest==4.6.4 pytest-cov

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -3,10 +3,6 @@ name: Daily tests
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull_request:
-    branches:
-      - master
-      - "[0-9]+.[0-9]+.X"
 
 jobs:
   test:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -3,6 +3,10 @@ name: Daily tests
 on:
   schedule:
     - cron: "0 0 * * *"
+  pull_request:
+    branches:
+      - master
+      - "[0-9]+.[0-9]+.X"
 
 jobs:
   test:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -35,4 +35,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          fail_ci_if_error: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,4 +53,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          fail_ci_if_error: true


### PR DESCRIPTION
#### What does this implement?

This PR fixes the error: `No matching distribution found for threadpoolctl>=2.0.0 (from scikit-learn)` in the daily tests.

#### Any other comments

This PR also ensures that workflow does not run errors when code coverage fails to upload.