### PR TITLE
[MNT] Fetch numpy and scipy nightly wheels from anaconda

### DIFF
--- a/.github/tools/cron/install.sh
+++ b/.github/tools/cron/install.sh
@@ -5,13 +5,14 @@ set -e
 echo "Upgrading pip and setuptools."
 pip install --upgrade pip setuptools
 
-echo "Installing numpy, scipy and cython."
-dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
-pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy cython
+echo "Installing numpy, scipy and scikit-learn."
+dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
+pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy scikit-learn
 
-echo "Installing scikit-learn."
-dev_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
-pip install --pre --upgrade --timeout=60 --extra-index $dev_url scikit-learn
+# Cython nightly build should be still fetched from the Rackspace container
+echo "Installing cython."
+dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
+pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
 
 echo "Installing pytest."
 pip install pytest==4.6.4 pytest-cov

--- a/.github/tools/integration/install.sh
+++ b/.github/tools/integration/install.sh
@@ -5,11 +5,8 @@ set -e
 echo "Upgrading pip and setuptools."
 pip install --upgrade pip setuptools
 
-echo "Installing numpy, scipy and cython."
-pip install numpy==$NUMPY_VERSION scipy==$SCIPY_VERSION cython==$CYTHON_VERSION
-
-echo "Installing scikit-learn."
-pip install scikit-learn==$SCIKIT_LEARN_VERSION
+echo "Installing numpy, scipy, cython and scikit-learn."
+pip install numpy==$NUMPY_VERSION scipy==$SCIPY_VERSION cython==$CYTHON_VERSION scikit-learn==$SCIKIT_LEARN_VERSION
 
 echo "Installing pytest."
 pip install pytest==4.6.4 pytest-cov

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,8 +1,14 @@
 name: Daily tests
 
+# on:
+#  schedule:
+# - cron: "0 0 * * *"
+
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  pull_request:
+    branches:
+      - master
+      - "[0-9]+.[0-9]+.X"
 
 jobs:
   test:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,14 +1,8 @@
 name: Daily tests
 
-# on:
-#  schedule:
-# - cron: "0 0 * * *"
-
 on:
-  pull_request:
-    branches:
-      - master
-      - "[0-9]+.[0-9]+.X"
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   test:


### PR DESCRIPTION
#### What does this implement?

This PR updates the `Daily tests` workflow to fetch the nightly wheels of `numpy` and `scipy` from Anaconda instead of the Rackspace container.

#### Any other comments?

`Cython` should be still fetched from the Rackspace container.
