### PR TITLE
[ENH] Add workflow to publish wheels and source distribution in PyPI

### DIFF
--- a/.github/tools/publish/download.sh
+++ b/.github/tools/publish/download.sh
@@ -5,5 +5,5 @@ set -e
 echo "Downloading scikit-lr $SCIKIT_LR_VERSION wheels and source distribution."
 python -m wheelhouse_uploader fetch --version $SCIKIT_LR_VERSION \
                                     --local-folder dist \
-                                    scikit-learn \
+                                    scikit-lr \
                                     https://pypi.anaconda.org/alfaro/simple/scikit-lr

--- a/.github/tools/publish/download.sh
+++ b/.github/tools/publish/download.sh
@@ -6,4 +6,4 @@ echo "Downloading scikit-lr $SCIKIT_LR_VERSION wheels and source distribution."
 python -m wheelhouse_uploader fetch --version $SCIKIT_LR_VERSION \
                                     --local-folder dist \
                                     scikit-lr \
-                                    https://pypi.anaconda.org/alfaro/simple/scikit-lr
+                                    https://pypi.anaconda.org/alfaro96/simple/scikit-lr

--- a/.github/tools/publish/download.sh
+++ b/.github/tools/publish/download.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo "Downloading scikit-lr $SCIKIT_LR_VERSION wheels and source distribution."
+python -m wheelhouse_uploader fetch --version $SKLEARN_VERSION \
+                                    --local-folder dist \
+                                    scikit-learn \
+                                    https://pypi.anaconda.org/alfaro/simple/scikit-lr

--- a/.github/tools/publish/download.sh
+++ b/.github/tools/publish/download.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Downloading scikit-lr $SCIKIT_LR_VERSION wheels and source distribution."
-python -m wheelhouse_uploader fetch --version $SKLEARN_VERSION \
+python -m wheelhouse_uploader fetch --version $SCIKIT_LR_VERSION \
                                     --local-folder dist \
                                     scikit-learn \
                                     https://pypi.anaconda.org/alfaro/simple/scikit-lr

--- a/.github/tools/publish/install.sh
+++ b/.github/tools/publish/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo "Upgrading pip."
+pip install --upgrade pip
+
+echo "Installing wheelhouse-uploader."
+pip install wheelhouse-uploader

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+# Workflow to publish the wheels and the source distribution in PyPI
+name: Publish PyPI
+
+on:
+  # Manual trigger run
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to upload to PyPI"
+        required: true
+
+      repository:
+        description: "The repository to upload to (PyPI or TestPyPI)"
+        required: true
+        default: "testpypi"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout scikit-lr
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Install dependencies
+        run: bash $GITHUB_WORKSPACE/.github/tools/publish/install.sh
+
+      - name: Download artifacts
+        run: bash $GITHUB_WORKSPACE/.github/tools/publish/download.sh
+        env:
+          SCIKIT_LR_VERSION: ${{ github.event.inputs.version }}
+
+      - name: Publish artifacts in PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        if: ${{ github.event.inputs.pypi_repo == "pypi" }}
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Publish artifacts in TestPyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        if: ${{ github.event.inputs.pypi_repo == "testpypi" }}
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,14 +36,14 @@ jobs:
 
       - name: Publish artifacts in PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2
-        if: ${{ github.event.inputs.pypi_repo == "pypi" }}
+        if: ${{ github.event.inputs.repository == "pypi" }}
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish artifacts in TestPyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2
-        if: ${{ github.event.inputs.pypi_repo == "testpypi" }}
+        if: ${{ github.event.inputs.repository == "testpypi" }}
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,13 @@ on:
   # Manual trigger run
   workflow_dispatch:
     inputs:
+      # The version to publish
       version:
-        description: "The version to upload to PyPI"
+        description: "Version"
         required: true
-
+      # The destination repository
       repository:
-        description: "The repository to upload to (PyPI or TestPyPI)"
+        description: "Repository"
         required: true
         default: "testpypi"
 


### PR DESCRIPTION
#### What does this implement?

This PR adds a new workflow to publish the wheels and the source distribution in `PyPI`, fetching the artifacts from the `Anaconda` repository.
